### PR TITLE
Remove /e modifier from the pattern of the preg_replace_callback call.

### DIFF
--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -304,7 +304,7 @@ abstract class sfTask
    */
   public function getDetailedDescription()
   {
-    return preg_replace_callback('/\[(.+?)\|(\w+)\]/se', function($m) { return $this->formatter->format($m[1], $m[2]); }, $this->detailedDescription);
+    return preg_replace_callback('/\[(.+?)\|(\w+)\]/s', function($m) { return $this->formatter->format($m[1], $m[2]); }, $this->detailedDescription);
   }
 
   /**


### PR DESCRIPTION
Second PR for issue #5 (first PR was #6) as I forgot to remove the /e modifier from the pattern in the function call.
