### PR TITLE
Remove deprecated /e modifier in preg_replace_callback call and remove use of $this in closure

### DIFF
--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -304,7 +304,7 @@ abstract class sfTask
    */
   public function getDetailedDescription()
   {
-    return preg_replace_callback('/\[(.+?)\|(\w+)\]/se', function($m) { return $this->formatter->format($m[1], $m[2]); }, $this->detailedDescription);
+    return preg_replace_callback('/\[(.+?)\|(\w+)\]/s', function($m) { return $this->formatter->format($m[1], $m[2]); }, $this->detailedDescription);
   }
 
   /**

--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -304,7 +304,10 @@ abstract class sfTask
    */
   public function getDetailedDescription()
   {
-    return preg_replace_callback('/\[(.+?)\|(\w+)\]/s', function($m) { return $this->formatter->format($m[1], $m[2]); }, $this->detailedDescription);
+    $formatter = $this->getFormatter();
+    return preg_replace_callback('/\[(.+?)\|(\w+)\]/s', function($matches) use ($formatter) {
+      return $formatter->format($matches[1], $matches[2]);
+    }, $this->detailedDescription);
   }
 
   /**


### PR DESCRIPTION
- /e modifier removal was forgotten in my previous PR #5 
- for BC with PHP 5.3, an intermediary variable is used in the closure to avoid the use of `$this` in a closure, which is only allowed since PHP 5.4
