### PR TITLE
Fix for exception handling in PHP 7

### DIFF
--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -478,9 +478,9 @@ abstract class sfTestFunctionalBase
   /**
    * Exception handler for the current test browser instance.
    *
-   * @param Exception $exception The exception
+   * @param $exception The exception
    */
-  function handleException(Exception $exception)
+  function handleException($exception)
   {
     $this->test()->error(sprintf('%s: %s', get_class($exception), $exception->getMessage()));
 

--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -570,7 +570,7 @@ class lime_test
     $this->error($type.': '.$message, $file, $line, $trace);
   }
 
-  public function handle_exception(Exception $exception)
+  public function handle_exception($exception)
   {
     $this->error(get_class($exception).': '.$exception->getMessage(), $exception->getFile(), $exception->getLine(), $exception->getTrace());
 


### PR DESCRIPTION
In PHP 7, exception handlers set using set_exception_handler are sometimes passed `Exception`s, but can also be passed `Error`s - both subtypes of a new parent class called `Throwable`.

http://php.net/manual/en/function.set-exception-handler.php

For compatibility with PHP 5 as well as 7, the recommendation is to remove the type hint entirely. http://php.net/manual/en/migration70.incompatible.php
