### PR TITLE
Refactor preg_replace() with /e modifier to preg_replace_callback()

### DIFF
--- a/lib/plugins/sfPropelPlugin/lib/vendor/phing/mappers/RegexpMapper.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/phing/mappers/RegexpMapper.php
@@ -90,7 +90,9 @@ class RegexpMapper implements FileNameMapper {
         $groups = (array) $this->reg->getGroups();            
         
         // replace \1 with value of $groups[1] and return the modified "to" string
-        return preg_replace('/\\\([\d]+)/e', "\$groups[$1]", $this->to);            
+        return preg_replace_callback('/\\\([\d]+)/', function ($match) use ($groups) {
+            return $groups[$match[1]];
+        }, $this->to);
     }
     
 }


### PR DESCRIPTION
`preg_replace()` with `/e` modifier was deprecated in PHP 5.5 and removed in PHP 7. This replaces its usages with equivalent functionality using `preg_replace_callback()`.

Fixes #12