### PR TITLE
Fix PHP 7.2 issue with type hinting

### DIFF
--- a/lib/yaml/sfYamlInline.php
+++ b/lib/yaml/sfYamlInline.php
@@ -135,7 +135,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + (integer) $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val)


### PR DESCRIPTION
Under PHP 7.2, warnings are produced such as:
```
Warning: A non-numeric value encountered in /var/www/lib/vendor/symfony/lib/yaml/sfYamlInline.php(138) : runtime-created function on line 1
```

This patch removes these warnings.