### PR TITLE
Prevent "Warning: ini_set(): A session is active. You cannot change t…

### DIFF
--- a/lib/user/sfBasicSecurityUser.class.php
+++ b/lib/user/sfBasicSecurityUser.class.php
@@ -252,7 +252,7 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
     }
 
     // force the max lifetime for session garbage collector to be greater than timeout
-    if (ini_get('session.gc_maxlifetime') < $this->options['timeout'])
+    if (session_status() !== PHP_SESSION_ACTIVE && ini_get('session.gc_maxlifetime') < $this->options['timeout'])
     {
       ini_set('session.gc_maxlifetime', $this->options['timeout']);
     }


### PR DESCRIPTION
…he session module's ini settings at this time in sfBasicSecurityUser.class.php on line 257"

PHP 7.2 changed the `ini_set` behaviour for session keys (see https://github.com/FriendsOfSymfony1/symfony1/issues/183 for a discussion). This patch prevents the warning.